### PR TITLE
fix(enocean): support 32-bit rolling code (RLC_ALGO=3) in secure telegrams

### DIFF
--- a/deviceclasses/enocean/enoceancomm.cpp
+++ b/deviceclasses/enocean/enoceancomm.cpp
@@ -1152,6 +1152,7 @@ uint8_t EnOceanSecurity::rlcSize()
   uint8_t rlcBytes = 0;
   if (rlcAlgo==1) rlcBytes = 2; // 16 bit RLC
   else if (rlcAlgo==2) rlcBytes = 3; // 24 bit RLC
+  else if (rlcAlgo==3) rlcBytes = 4; // 32 bit RLC
   return rlcBytes;
 }
 


### PR DESCRIPTION
## Problem

`EnOceanSecurity::rlcSize()` (`deviceclasses/enocean/enoceancomm.cpp`) only handled `RLC_ALGO` 1 (16-bit) and 2 (24-bit). For **`RLC_ALGO=3` (32-bit RLC — e.g. SLF `0xF3`)** it fell through and returned **0**.

Consequences for any secure device using a 32-bit RLC:
- During secure teach-in parsing (`SLF | RLC | KEY`) the 4 RLC bytes were not consumed, so the AES key was **misaligned by 4 bytes** → wrong key.
- The rolling code defaulted to 0.
- CMAC verification of every incoming secure telegram failed: `No CMAC match with transmitted RLC 0` → the device could never be paired or decrypted.

## Fix

Add the missing case in `rlcSize()`:

    else if (rlcAlgo==3) rlcBytes = 4; // 32 bit RLC

`calcCMAC()`, the RLC-window masking and `mRollingCounter` (uint32_t) already handle a 4-byte RLC generically, so no other changes are needed.

## Validation

Reproduced and fixed with a real D2-14-41 secure multisensor (SLF `0xF3`) on a USB300 modem:
- **Before:** `No CMAC match with transmitted RLC 0` on every telegram; device never pairs.
- **After:** secure teach-in establishes, the device pairs, and encrypted telegrams decrypt and decode correctly.

The 21-byte teach-in payload also fits exactly only with a 4-byte RLC (`1 SLF + 4 RLC + 16 KEY = 21`), confirming `RLC_ALGO=3 → 4 bytes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
